### PR TITLE
Predef.assert-like API 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: scala
 jdk: openjdk8
 
 scala:
-  - 2.10.7
   - 2.11.12
   - 2.12.8
   - 2.13.0

--- a/README.md
+++ b/README.md
@@ -18,68 +18,60 @@ libraryDependencies += "com.eed3si9n.expecty" %% "expecty" % "0.11.0" % Test
 ## Code Examples
 
 ```scala
+Welcome to Scala 2.12.8 (OpenJDK 64-Bit Server VM, Java 1.8.0_212).
+Type in expressions for evaluation. Or try :help.
+
+scala> import com.eed3si9n.expecty.Expecty.assert
 import com.eed3si9n.expecty.Expecty.assert
 
-case class Person(name: String = "Fred", age: Int = 42) {
-  def say(words: String*) = words.mkString(" ")
-}
+scala> case class Person(name: String = "Fred", age: Int = 42) {
+     |   def say(words: String*) = words.mkString(" ")
+     | }
+defined class Person
 
-val person = Person()
+scala> val person = Person()
+person: Person = Person(Fred,42)
 
-// Passing expectations
+scala> // Passing expectations
 
-assert {
-  person.name == "Fred"
-  person.age * 2 == 84
-  person.say("Hi", "from", "Expecty!") == "Hi from Expecty!"
-}
+scala> assert(person.name == "Fred")
 
-// Failing expectation
+scala> assert(person.age * 2 == 84)
 
-val word1 = "ping"
-val word2 = "pong"
+scala> assert(person.say("Hi", "from", "Expecty!") == "Hi from Expecty!")
 
-assert {
-  person.say(word1, word2) == "pong pong"
-}
+scala> // Failing expectation
 
-/*
-Output:
+scala> val word1 = "ping"
+word1: String = ping
 
-java.lang.AssertionError:
+scala> val word2 = "pong"
+word2: String = pong
 
-person.say(word1, word2) == "pong pong"
-|      |   |      |      |
-|      |   ping   pong   false
-|      ping pong
-Person(Fred,42)
-*/
+scala> assert(person.say(word1, word2) == "pong pong")
+java.lang.AssertionError: assertion failed
 
-// Continue despite failing predicate
+assert(person.say(word1, word2) == "pong pong")
+       |      |   |      |      |
+       |      |   ping   pong   false
+       |      ping pong
+       Person(Fred,42)
 
-val expect2 = new Expecty(failEarly = false)
+  at com.eed3si9n.expecty.Expecty$ExpectyListener.expressionRecorded(Expecty.scala:35)
+  at com.eed3si9n.expecty.RecorderRuntime.recordExpression(RecorderRuntime.scala:39)
+  ... 36 elided
 
-expect2 {
-  person.name == "Frog"
-  person.age * 2 == 73
-}
+scala> assert(person.age * 2 == 73, "age is not right")
+java.lang.AssertionError: assertion failed: age is not right
 
-/*
-Output:
+assert(person.age * 2 == 73, "age is not right")
+       |      |   |   |
+       |      42  84  false
+       Person(Fred,42)
 
-java.lang.AssertionError:
-
-person.name == "Frog"
-|      |    |
-|      Fred false
-Person(Fred,42)
-
-
-person.age * 2 == 73
-|      |   |   |
-|      42  84  false
-Person(Fred,42)
-*/
+  at com.eed3si9n.expecty.Expecty$ExpectyListener.expressionRecorded(Expecty.scala:35)
+  at com.eed3si9n.expecty.RecorderRuntime.recordExpression(RecorderRuntime.scala:39)
+  ... 36 elided
 ```
 
 ## Further Examples

--- a/jvm/src/test/scala/org/expecty/ExpectyExample.scala
+++ b/jvm/src/test/scala/org/expecty/ExpectyExample.scala
@@ -51,30 +51,4 @@ object ExpectyExample extends App {
   |      ping pong
   Person(Fred,42)
   */
-
-  // Continue despite failing predicate
-
-  val expect2 = new Expecty(failEarly = false)
-
-  expect2 {
-    person.name == "Frog"
-    person.age * 2 == 73
-  }
-
-  /*
-  Output:
-
-  java.lang.AssertionError:
-
-  person.name == "Frog"
-  |      |    |
-  |      Fred false
-  Person(Fred,42)
-
-
-  person.age * 2 == 73
-  |      |   |   |
-  |      42  84  false
-  Person(Fred,42)
-  */
 }

--- a/jvm/src/test/scala/org/expecty/ExpectyRenderingSpec.scala
+++ b/jvm/src/test/scala/org/expecty/ExpectyRenderingSpec.scala
@@ -19,14 +19,15 @@ import junit.framework.ComparisonFailure
 import com.eed3si9n.expecty.Expecty
 
 class ExpectyRenderingSpec {
-  val assert = new Expecty(printAsts = true)
+  val assert = new Expecty() // (printAsts = true)
 
   def isDotty: Boolean =
     scala.util.Try(Class.forName("dotty.DottyPredef$")).isSuccess
 
   @Test
   def literals(): Unit = {
-    outputs("""
+    outputs("""assertion failed
+
 "abc".length() == 2
       |        |
       3        false
@@ -40,7 +41,8 @@ class ExpectyRenderingSpec {
   @Test
   def object_apply(): Unit = {
     if (isDotty) {
-      outputs("""
+      outputs("""assertion failed
+
 List() == List(1, 2)
 |      |  |
 List() |  List(1, 2)
@@ -51,7 +53,8 @@ List() |  List(1, 2)
         }
       }
     } else {
-      outputs("""
+      outputs("""assertion failed
+
 List() == List(1, 2)
        |  |
        |  List(1, 2)
@@ -67,7 +70,8 @@ List() == List(1, 2)
   @Test
   def object_apply_2(): Unit = {
     if (isDotty) {
-      outputs("""
+      outputs("""assertion failed
+
 List(1, 2) == List()
 |          |  |
 List(1, 2) |  List()
@@ -78,7 +82,8 @@ List(1, 2) |  List()
         }
       }
     } else {
-      outputs("""
+      outputs("""assertion failed
+
 List(1, 2) == List()
 |          |
 List(1, 2) false
@@ -94,7 +99,8 @@ List(1, 2) false
   def infix_operators(): Unit = {
     val str = "abc"
 
-    outputs("""
+    outputs("""assertion failed
+
 str + "def" == "other"
 |   |       |
 abc abcdef  false
@@ -109,7 +115,8 @@ abc abcdef  false
   def null_value(): Unit = {
     val x = null
 
-    outputs("""
+    outputs("""assertion failed
+
 x == "null"
 | |
 | false
@@ -142,7 +149,8 @@ null
   def arithmetic_expressions(): Unit = {
     val one = 1
 
-    outputs("""
+    outputs("""assertion failed
+
 one + 2 == 4
 |   |   |
 1   3   false
@@ -157,7 +165,8 @@ one + 2 == 4
   def property_read(): Unit = {
     val person = Person()
 
-    outputs("""
+    outputs("""assertion failed
+
 person.age == 43
 |      |   |
 |      42  false
@@ -172,7 +181,8 @@ Person(Fred,42)
   @Test
   def method_call_zero_args(): Unit = {
     val person = Person()
-    outputs("""
+    outputs("""assertion failed
+
 person.doIt() == "pending"
 |      |      |
 |      done   false
@@ -189,7 +199,8 @@ Person(Fred,42)
     val person = Person()
     val word = "hey"
 
-    outputs("""
+    outputs("""assertion failed
+
 person.sayTwice(word) == "hoho"
 |      |        |     |
 |      heyhey   hey   false
@@ -207,7 +218,8 @@ Person(Fred,42)
     val word1 = "hey"
     val word2 = "ho"
 
-    outputs("""
+    outputs("""assertion failed
+
 person.sayTwo(word1, word2) == "hoho"
 |      |      |      |      |
 |      heyho  hey    ho     false
@@ -226,7 +238,8 @@ Person(Fred,42)
     val word2 = "bar"
     val word3 = "baz"
 
-    outputs("""
+    outputs("""assertion failed
+
 person.sayAll(word1, word2, word3) == "hoho"
 |      |      |      |      |      |
 |      |      foo    bar    baz    false
@@ -243,7 +256,8 @@ Person(Fred,42)
   def nested_property_reads_and_method_calls(): Unit = {
     val person = Person()
 
-    outputs("""
+    outputs("""assertion failed
+
 person.sayTwo(person.sayTwice(person.name), "bar") == "hoho"
 |      |      |      |        |      |             |
 |      |      |      FredFred |      Fred          false
@@ -265,7 +279,8 @@ Person(Fred,42)
 
 
     if (isDotty) {
-      outputs("""
+      outputs("""assertion failed
+
 Car(brand, model).brand == "Audi"
 |   |      |            |
 |   BMW    M5           false
@@ -276,7 +291,8 @@ BMW M5
         }
       }
     } else {
-      outputs("""
+      outputs("""assertion failed
+
 Car(brand, model).brand == "Audi"
 |   |      |      |     |
 |   BMW    M5     BMW   false
@@ -313,7 +329,8 @@ BMW M5
   @Test
   def tuple(): Unit = {
     if (isDotty) {
-      outputs("""
+      outputs("""assertion failed
+
 (1, 2)._1 == 3
  |     |  |
  (1,2) 1  false
@@ -323,7 +340,8 @@ BMW M5
       }
     }
     } else {
-      outputs("""
+      outputs("""assertion failed
+
 (1, 2)._1 == 3
 |      |  |
 (1,2)  1  false
@@ -397,7 +415,8 @@ BMW M5
   @Test
   def option_type(): Unit = {
     outputs(
-      """
+      """assertion failed
+
 Some(23) == Some(22)
 |        |  |
 Some(23) |  Some(22)
@@ -426,6 +445,32 @@ Some(23) |  Some(22)
 //      }
 //    }
 //  }
+
+  @Test
+  def message(): Unit = {
+    val person = Person()
+    if (isDotty) {
+      outputs("""assertion failed: something something
+
+person.age == 43
+|      |   |
+|      42  false
+Person(Fred,42)
+      """) {
+        assert(person.age == 43, "something something")
+      }
+    } else {
+      outputs("""assertion failed: something something
+
+assert(person.age == 43, "something something")
+       |      |   |
+       |      42  false
+       Person(Fred,42)
+      """) {
+        assert(person.age == 43, "something something")
+      }
+    }
+  }
 
   def outputs(rendering: String)(expectation: => Unit): Unit = {
     def normalize(s: String) = augmentString(s.trim()).lines.mkString

--- a/jvm/src/test/scala/org/expecty/ExpectySpec.scala
+++ b/jvm/src/test/scala/org/expecty/ExpectySpec.scala
@@ -43,24 +43,6 @@ class ExpectySpec {
     assert(name.endsWith("Expecty!"))
   }
 
-  @Test
-  def passingMultiExpectation(): Unit = {
-    assert {
-      name.length == 16
-      name.startsWith("Hi")
-      name.endsWith("Expecty!")
-    }
-  }
-
-  @Test(expected = classOf[AssertionError])
-  def failingMultiExpectation(): Unit = {
-    assert {
-      name.length == 16
-      name.startsWith("Ho")
-      name.endsWith("Expecty!")
-    }
-  }
-
   //TODO: needs assertion
   // @Test(expected = classOf[AssertionError])
   // def lateFailingExpectation(): Unit = {

--- a/shared/src/main/scala-2/com/eed3si9n/expecty/Recorder.scala
+++ b/shared/src/main/scala-2/com/eed3si9n/expecty/Recorder.scala
@@ -15,9 +15,8 @@ package com.eed3si9n.expecty
 
 import language.experimental.macros
 
-// should have two type parameters; one for recorded type, another for returned type
-// so far failed to implement the macro side of this
 abstract class Recorder {
   def listener: RecorderListener[Boolean]
-  def apply(recording: Boolean): Boolean = macro RecorderMacro.apply
+  def apply(recording: Boolean): Unit = macro RecorderMacro1.apply
+  def apply(recording: Boolean, message: => String): Unit = macro RecorderMacro.apply
 }

--- a/shared/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/shared/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
@@ -43,16 +43,13 @@ class RecorderMacro[C <: Context](val context: C) {
   }
 
   private[this] def recordExpressions(recording: Tree): List[Tree] = {
-    val exprs = splitExpressions(recording)
-    exprs.flatMap { expr =>
-      val text = getText(expr)
-      val ast = showRaw(expr)
-      try {
-        List(resetValues, recordExpression(text, ast, expr))
-      } catch {
-        case e: Throwable => throw new RuntimeException(
-          "Expecty: Error rewriting expression.\nText: " + text + "\nAST : " + ast, e)
-      }
+    val text = getText(recording)
+    val ast = showRaw(recording)
+    try {
+      List(resetValues, recordExpression(text, ast, recording))
+    } catch {
+      case e: Throwable => throw new RuntimeException(
+        "Expecty: Error rewriting expression.\nText: " + text + "\nAST : " + ast, e)
     }
   }
 

--- a/shared/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
+++ b/shared/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
@@ -19,4 +19,6 @@ abstract class Recorder {
   def listener: RecorderListener[Boolean]
   inline def apply(recording: Boolean): Unit =
     ${ RecorderMacro.apply('recording, 'listener) }
+  inline def apply(recording: Boolean, message: => String): Unit =
+    ${ RecorderMacro.apply('recording, 'message, 'listener) }
 }

--- a/shared/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/shared/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
@@ -32,12 +32,6 @@ object RecorderMacro {
     import reflect._
     val termArg: Term = recording.unseal.underlyingArgument
 
-    def splitExpressions(recording: Term): List[Term] =
-      recording match {
-        case Block(xs, y) => (xs collect { case t: Term => t }) ::: List(y)
-        case _ => List(recording)
-      }
-
     def getText(expr: Tree): String = {
       val pos = expr.pos
       (" " * pos.startColumn) + pos.sourceCode
@@ -60,19 +54,16 @@ object RecorderMacro {
         }
 
         def recordExpressions(recording: Term): List[Term] = {
-          val exprs = splitExpressions(recording)
-          exprs flatMap { expr =>
-            val text = getText(expr)
-            val ast = expr.showExtractors
-            try {
-              List(
-                '{ recorderRuntime.resetValues() }.unseal,
-                recordExpression(text, ast, expr)
-              )
-            } catch {
-              case e: Throwable => throw new RuntimeException(
-                "Expecty: Error rewriting expression.\nText: " + text + "\nAST : " + ast, e)
-            }
+          val text = getText(recording)
+          val ast = recording.showExtractors
+          try {
+            List(
+              '{ recorderRuntime.resetValues() }.unseal,
+              recordExpression(text, ast, recording)
+            )
+          } catch {
+            case e: Throwable => throw new RuntimeException(
+              "Expecty: Error rewriting expression.\nText: " + text + "\nAST : " + ast, e)
           }
         }
 

--- a/shared/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/shared/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
@@ -22,6 +22,13 @@ object RecorderMacro {
   def apply(
       recording: Expr[Boolean],
       listener: Expr[RecorderListener[Boolean]])(implicit reflect: Reflection): Expr[Unit] = {
+    apply(recording, '{""}, listener)
+  }
+
+  def apply(
+      recording: Expr[Boolean],
+      message: Expr[String],
+      listener: Expr[RecorderListener[Boolean]])(implicit reflect: Reflection): Expr[Unit] = {
     import reflect._
     val termArg: Term = recording.unseal.underlyingArgument
 
@@ -38,6 +45,7 @@ object RecorderMacro {
 
     '{
       val recorderRuntime: RecorderRuntime = new RecorderRuntime($listener)
+      recorderRuntime.recordMessage($message)
       ${
         val runtimeSym = '[RecorderRuntime].unseal.symbol match {
           case IsClassDefSymbol(sym) => sym

--- a/shared/src/main/scala/com/eed3si9n/expecty/Expecty.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/Expecty.scala
@@ -14,26 +14,25 @@
 
 package com.eed3si9n.expecty
 
-class Expecty(failEarly: Boolean = true, showTypes: Boolean = false,
-              printAsts: Boolean = false, printExprs: Boolean = false) extends Recorder {
-  class ExpectyListener extends RecorderListener[Boolean] {
-    override def expressionRecorded(recordedExpr: RecordedExpression[Boolean]): Unit = {
-      lazy val rendering: String = new ExpressionRenderer(showTypes).render(recordedExpr)
-      if (printAsts) println(recordedExpr.ast + "\n")
-      if (printExprs) println(rendering)
-      if (!recordedExpr.value && failEarly) {
-        throw new AssertionError("\n\n" + rendering)
-      }
-    }
+class Expecty extends Recorder {
+  val failEarly: Boolean = true
+  val showTypes: Boolean = false
+  // val printAsts: Boolean = false
+  // val printExprs: Boolean = false
 
-    override def recordingCompleted(recording: Recording[Boolean]): Unit = {
-      if (!failEarly) {
-        val failedExprs = recording.recordedExprs.filter(!_.value)
-        if (!failedExprs.isEmpty) {
-          val renderer = new ExpressionRenderer(showTypes)
-          val renderings = failedExprs.reverse.map(renderer.render(_))
-          throw new AssertionError("\n\n" + renderings.mkString("\n\n"))
-        }
+  class ExpectyListener extends RecorderListener[Boolean] {
+    override def expressionRecorded(
+        recordedExpr: RecordedExpression[Boolean], recordedMessage: Function0[String]): Unit = {
+      lazy val rendering: String = new ExpressionRenderer(showTypes).render(recordedExpr)
+      // if (printAsts) println(recordedExpr.ast + "\n")
+      // if (printExprs) println(rendering)
+      if (!recordedExpr.value && failEarly) {
+        val msg = recordedMessage()
+        val header =
+          "assertion failed" +
+            (if (msg == "") ""
+            else ": " + msg)
+        throw new AssertionError(header + "\n\n" + rendering)
       }
     }
   }

--- a/shared/src/main/scala/com/eed3si9n/expecty/RecorderListener.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/RecorderListener.scala
@@ -15,6 +15,6 @@ package com.eed3si9n.expecty
 
 trait RecorderListener[T] {
   def valueRecorded(recordedValue: RecordedValue): Unit = {}
-  def expressionRecorded(recordedExpr: RecordedExpression[T]): Unit = {}
-  def recordingCompleted(recording: Recording[T]): Unit = {}
+  def expressionRecorded(recordedExpr: RecordedExpression[T], recordedMessage: Function0[String]): Unit = {}
+  def recordingCompleted(recording: Recording[T], recordedMessage: Function0[String]): Unit = {}
 }

--- a/shared/src/main/scala/com/eed3si9n/expecty/RecorderRuntime.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/RecorderRuntime.scala
@@ -15,8 +15,9 @@ package com.eed3si9n.expecty
 
 // one instance per recording
 class RecorderRuntime(listener: RecorderListener[Boolean]) {
-  var recordedValues: List[RecordedValue] = _
-  var recordedExprs: List[RecordedExpression[Boolean]] = List.empty
+  protected var recordedValues: List[RecordedValue] = _
+  protected var recordedExprs: List[RecordedExpression[Boolean]] = List.empty
+  protected var recordedMessage: Function0[String] = () => ""
 
   def resetValues(): Unit = {
     recordedValues = List.empty
@@ -29,16 +30,19 @@ class RecorderRuntime(listener: RecorderListener[Boolean]) {
     value
   }
 
+  def recordMessage(message: => String): Unit = {
+    recordedMessage = () => message
+  }
+
   def recordExpression(text: String, ast: String, value: Boolean): Unit = {
     val recordedExpr = RecordedExpression(text, ast, value, recordedValues)
-    listener.expressionRecorded(recordedExpr)
+    listener.expressionRecorded(recordedExpr, recordedMessage)
     recordedExprs = recordedExpr :: recordedExprs
   }
 
-  def completeRecording(): Boolean = {
+  def completeRecording(): Unit = {
     val lastRecorded = recordedExprs.head
     val recording = Recording(lastRecorded.value, recordedExprs)
-    listener.recordingCompleted(recording)
-    recording.value
+    listener.recordingCompleted(recording, recordedMessage)
   }
 }


### PR DESCRIPTION
Fixes #4

This changes the return type to Unit, and adds an overload that accepts a message.