### PR TITLE
Allow for non-unit return types

### DIFF
--- a/shared/src/main/scala-2/com/eed3si9n/expecty/Recorder.scala
+++ b/shared/src/main/scala-2/com/eed3si9n/expecty/Recorder.scala
@@ -15,8 +15,8 @@ package com.eed3si9n.expecty
 
 import language.experimental.macros
 
-abstract class Recorder {
-  def listener: RecorderListener[Boolean]
-  def apply(recording: Boolean): Unit = macro RecorderMacro1.apply
-  def apply(recording: Boolean, message: => String): Unit = macro RecorderMacro.apply
+abstract class Recorder[R, A] {
+  def listener: RecorderListener[R, A]
+  def apply(recording: R): A = macro RecorderMacro1.apply[R, A]
+  def apply(recording: R, message: => String): A = macro RecorderMacro.apply[R, A]
 }

--- a/shared/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
+++ b/shared/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
@@ -15,10 +15,10 @@ package com.eed3si9n.expecty
 
 import language.experimental.macros
 
-abstract class Recorder {
-  def listener: RecorderListener[Boolean]
-  inline def apply(recording: Boolean): Unit =
+abstract class Recorder[R, A] {
+  def listener: RecorderListener[R, A]
+  inline def apply(recording: R): A =
     ${ RecorderMacro.apply('recording, 'listener) }
-  inline def apply(recording: Boolean, message: => String): Unit =
+  inline def apply(recording: R, message: => String): A =
     ${ RecorderMacro.apply('recording, 'message, 'listener) }
 }

--- a/shared/src/main/scala/com/eed3si9n/expecty/Expecty.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/Expecty.scala
@@ -14,13 +14,13 @@
 
 package com.eed3si9n.expecty
 
-class Expecty extends Recorder {
+class Expecty extends Recorder[Boolean, Unit] {
   val failEarly: Boolean = true
   val showTypes: Boolean = false
   // val printAsts: Boolean = false
   // val printExprs: Boolean = false
 
-  class ExpectyListener extends RecorderListener[Boolean] {
+  class ExpectyListener extends RecorderListener[Boolean, Unit] {
     override def expressionRecorded(
         recordedExpr: RecordedExpression[Boolean], recordedMessage: Function0[String]): Unit = {
       lazy val rendering: String = new ExpressionRenderer(showTypes).render(recordedExpr)
@@ -35,6 +35,9 @@ class Expecty extends Recorder {
         throw new AssertionError(header + "\n\n" + rendering)
       }
     }
+
+    override def recordingCompleted(
+        recording: Recording[Boolean], recordedMessage: Function0[String]) = {}
   }
 
   override lazy val listener = new ExpectyListener

--- a/shared/src/main/scala/com/eed3si9n/expecty/RecorderListener.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/RecorderListener.scala
@@ -13,8 +13,8 @@
 */
 package com.eed3si9n.expecty
 
-trait RecorderListener[T] {
+trait RecorderListener[T, A] {
   def valueRecorded(recordedValue: RecordedValue): Unit = {}
   def expressionRecorded(recordedExpr: RecordedExpression[T], recordedMessage: Function0[String]): Unit = {}
-  def recordingCompleted(recording: Recording[T], recordedMessage: Function0[String]): Unit = {}
+  def recordingCompleted(recording: Recording[T], recordedMessage: Function0[String]): A
 }

--- a/shared/src/main/scala/com/eed3si9n/expecty/RecorderRuntime.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/RecorderRuntime.scala
@@ -14,9 +14,9 @@
 package com.eed3si9n.expecty
 
 // one instance per recording
-class RecorderRuntime(listener: RecorderListener[Boolean]) {
+class RecorderRuntime[R, A](listener: RecorderListener[R, A]) {
   protected var recordedValues: List[RecordedValue] = _
-  protected var recordedExprs: List[RecordedExpression[Boolean]] = List.empty
+  protected var recordedExprs: List[RecordedExpression[R]] = List.empty
   protected var recordedMessage: Function0[String] = () => ""
 
   def resetValues(): Unit = {
@@ -34,13 +34,13 @@ class RecorderRuntime(listener: RecorderListener[Boolean]) {
     recordedMessage = () => message
   }
 
-  def recordExpression(text: String, ast: String, value: Boolean): Unit = {
+  def recordExpression(text: String, ast: String, value: R): Unit = {
     val recordedExpr = RecordedExpression(text, ast, value, recordedValues)
     listener.expressionRecorded(recordedExpr, recordedMessage)
     recordedExprs = recordedExpr :: recordedExprs
   }
 
-  def completeRecording(): Unit = {
+  def completeRecording(): A = {
     val lastRecorded = recordedExprs.head
     val recording = Recording(lastRecorded.value, recordedExprs)
     listener.recordingCompleted(recording, recordedMessage)


### PR DESCRIPTION
This changes the internal API to allow to return some other types than Unit, so that people can use leverage the macro to declare their own assertion functions, returing Either/Try, etc.