### PR TITLE
Adds source location 

### DIFF
--- a/jvm/src/test/scala/org/expecty/ExpectyLocationSpec.scala
+++ b/jvm/src/test/scala/org/expecty/ExpectyLocationSpec.scala
@@ -19,7 +19,7 @@ import junit.framework.ComparisonFailure
 import com.eed3si9n.expecty.Expecty
 
 class ExpectyLocationSpec {
-  val assert = new Expecty(true) // (displayLoc = true)
+  val assert = new Expecty { override val showLocation = true }
 
   @Test
   def position(): Unit = {

--- a/jvm/src/test/scala/org/expecty/ExpectyLocationSpec.scala
+++ b/jvm/src/test/scala/org/expecty/ExpectyLocationSpec.scala
@@ -1,0 +1,60 @@
+/*
+* Copyright 2012 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*     http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package foo
+
+import org.junit.Assert._
+import org.junit.Test
+import junit.framework.ComparisonFailure
+import com.eed3si9n.expecty.Expecty
+
+class ExpectyLocationSpec {
+  val assert = new Expecty(true) // (displayLoc = true)
+
+  @Test
+  def position(): Unit = {
+    outputs("""assertion failed (jvm/src/test/scala/org/expecty/ExpectyLocationSpec.scala:32)
+
+"abc".length() == 2
+      |        |
+      3        false
+    """) {
+      assert {
+        "abc".length() == 2
+      }
+    }
+  }
+
+
+  def outputs(rendering: String)(expectation: => Unit): Unit = {
+    def normalize(s: String) = augmentString(s.trim()).lines.mkString
+
+    try {
+      expectation
+      fail("Expectation should have failed but didn't")
+    }
+    catch  {
+      case e: AssertionError => {
+        val expected = normalize(rendering)
+        val actual = normalize(e.getMessage).replaceAll("@[0-9a-f]*", "@\\.\\.\\.")
+        if (actual != expected) {
+          throw new ComparisonFailure(s"Expectation output doesn't match: ${e.getMessage}",
+            expected, actual)
+        }
+      }
+    }
+  }
+
+
+}
+

--- a/shared/src/main/scala/com/eed3si9n/expecty/Expecty.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/Expecty.scala
@@ -14,9 +14,10 @@
 
 package com.eed3si9n.expecty
 
-class Expecty(displayLoc: Boolean = false) extends Recorder[Boolean, Unit] {
+class Expecty extends Recorder[Boolean, Unit] {
   val failEarly: Boolean = true
   val showTypes: Boolean = false
+  val showLocation: Boolean = false
   // val printAsts: Boolean = false
   // val printExprs: Boolean = false
 
@@ -28,7 +29,7 @@ class Expecty(displayLoc: Boolean = false) extends Recorder[Boolean, Unit] {
       // if (printExprs) println(rendering)
       if (!recordedExpr.value && failEarly) {
         val loc = recordedExpr.location
-        val locStr = if(displayLoc) " (" + loc.relativePath + ":" + loc.line + ")" else ""
+        val locStr = if(showLocation) " (" + loc.relativePath + ":" + loc.line + ")" else ""
         val msg = recordedMessage()
         val header =
           "assertion failed" + locStr +

--- a/shared/src/main/scala/com/eed3si9n/expecty/Expecty.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/Expecty.scala
@@ -14,7 +14,7 @@
 
 package com.eed3si9n.expecty
 
-class Expecty extends Recorder[Boolean, Unit] {
+class Expecty(displayLoc: Boolean = false) extends Recorder[Boolean, Unit] {
   val failEarly: Boolean = true
   val showTypes: Boolean = false
   // val printAsts: Boolean = false
@@ -27,9 +27,11 @@ class Expecty extends Recorder[Boolean, Unit] {
       // if (printAsts) println(recordedExpr.ast + "\n")
       // if (printExprs) println(rendering)
       if (!recordedExpr.value && failEarly) {
+        val loc = recordedExpr.location
+        val locStr = if(displayLoc) " (" + loc.relativePath + ":" + loc.line + ")" else ""
         val msg = recordedMessage()
         val header =
-          "assertion failed" +
+          "assertion failed" + locStr +
             (if (msg == "") ""
             else ": " + msg)
         throw new AssertionError(header + "\n\n" + rendering)

--- a/shared/src/main/scala/com/eed3si9n/expecty/RecordedExpression.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/RecordedExpression.scala
@@ -15,7 +15,7 @@ package com.eed3si9n.expecty
 
 // might hold more information in the future (for example the kind of expression),
 // or might be turned into an expression tree
-case class RecordedExpression[T](text: String, ast: String, value: T, recordedValues: List[RecordedValue]) {
+case class RecordedExpression[T](text: String, ast: String, value: T, recordedValues: List[RecordedValue], location: Location) {
 }
 
 

--- a/shared/src/main/scala/com/eed3si9n/expecty/RecorderRuntime.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/RecorderRuntime.scala
@@ -34,8 +34,8 @@ class RecorderRuntime[R, A](listener: RecorderListener[R, A]) {
     recordedMessage = () => message
   }
 
-  def recordExpression(text: String, ast: String, value: R): Unit = {
-    val recordedExpr = RecordedExpression(text, ast, value, recordedValues)
+  def recordExpression(text: String, ast: String, value: R, location: Location): Unit = {
+    val recordedExpr = RecordedExpression(text, ast, value, recordedValues, location)
     listener.expressionRecorded(recordedExpr, recordedMessage)
     recordedExprs = recordedExpr :: recordedExprs
   }

--- a/shared/src/main/scala/com/eed3si9n/expecty/SourceLocation.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/SourceLocation.scala
@@ -1,0 +1,8 @@
+package com.eed3si9n.expecty
+
+final case class Location(
+  path: String,
+  relativePath: String,
+  line: Int
+)
+


### PR DESCRIPTION
* The source location contains both absolute and relative (to the wd at build time) paths, as well as the line number.
* The location information is communicated to the front-end via the RecordedExpression.
* Adds a flag (disabled by default) to the `Expecty` constructor to display the source location in the error message.