### PR TITLE
Adds an "all" method on the Expecty class

### DIFF
--- a/jvm/src/test/scala/org/expecty/ExpectyRenderingSpec.scala
+++ b/jvm/src/test/scala/org/expecty/ExpectyRenderingSpec.scala
@@ -16,10 +16,11 @@ package foo
 import org.junit.Assert._
 import org.junit.Test
 import junit.framework.ComparisonFailure
-import com.eed3si9n.expecty.Expecty
+import com.eed3si9n.expecty.{Expecty, VarargsExpecty}
 
 class ExpectyRenderingSpec {
   val assert = new Expecty() // (printAsts = true)
+  val expect = new VarargsExpecty
 
   def isDotty: Boolean =
     scala.util.Try(Class.forName("dotty.DottyPredef$")).isSuccess
@@ -473,7 +474,7 @@ assert(person.age == 43, "something something")
   }
 
   @Test
-  def literalsAll(): Unit = {
+  def literalsVarargs(): Unit = {
     val maybeComma = if(isDotty) "" else ","
     outputs(s"""assertion failed
 
@@ -481,7 +482,7 @@ assert(person.age == 43, "something something")
       |        |
       3        false
     """) {
-      assert.all(
+      expect(
         "abc".length() == 3,
         "def".length() == 2,
         "fgh".length() == 3

--- a/jvm/src/test/scala/org/expecty/ExpectyRenderingSpec.scala
+++ b/jvm/src/test/scala/org/expecty/ExpectyRenderingSpec.scala
@@ -472,6 +472,23 @@ assert(person.age == 43, "something something")
     }
   }
 
+  @Test
+  def literalsAll(): Unit = {
+    val maybeComma = if(isDotty) "" else ","
+    outputs(s"""assertion failed
+
+"def".length() == 2$maybeComma
+      |        |
+      3        false
+    """) {
+      assert.all(
+        "abc".length() == 3,
+        "def".length() == 2,
+        "fgh".length() == 3
+      )
+    }
+  }
+
   def outputs(rendering: String)(expectation: => Unit): Unit = {
     def normalize(s: String) = augmentString(s.trim()).lines.mkString
 

--- a/jvm/src/test/scala/org/expecty/ExpectySpec.scala
+++ b/jvm/src/test/scala/org/expecty/ExpectySpec.scala
@@ -14,7 +14,7 @@
 package foo
 
 import org.junit.Test
-import com.eed3si9n.expecty.Expecty.assert
+import com.eed3si9n.expecty.Expecty.{assert, expect}
 
 class ExpectySpec {
   val name = "Hi from Expecty!"
@@ -45,7 +45,7 @@ class ExpectySpec {
 
   @Test
   def multiplePassingExpectationsUsingAll(): Unit = {
-    assert.all(
+    expect(
       name.length == 16,
       name.startsWith("Hi"),
       name.endsWith("Expecty!")
@@ -53,8 +53,8 @@ class ExpectySpec {
   }
 
   @Test(expected = classOf[AssertionError])
-  def mixedPassingAndFailingExpectationsUsingAll(): Unit = {
-    assert.all(
+  def mixedPassingAndFailingExpectationsUsingExpect(): Unit = {
+    expect(
       name.length == 16,
       name.startsWith("Ho"),
       name.endsWith("Expecty!")

--- a/jvm/src/test/scala/org/expecty/ExpectySpec.scala
+++ b/jvm/src/test/scala/org/expecty/ExpectySpec.scala
@@ -43,6 +43,25 @@ class ExpectySpec {
     assert(name.endsWith("Expecty!"))
   }
 
+  @Test
+  def multiplePassingExpectationsUsingAll(): Unit = {
+    assert.all(
+      name.length == 16,
+      name.startsWith("Hi"),
+      name.endsWith("Expecty!")
+    )
+  }
+
+  @Test(expected = classOf[AssertionError])
+  def mixedPassingAndFailingExpectationsUsingAll(): Unit = {
+    assert.all(
+      name.length == 16,
+      name.startsWith("Ho"),
+      name.endsWith("Expecty!")
+    )
+  }
+
+
   //TODO: needs assertion
   // @Test(expected = classOf[AssertionError])
   // def lateFailingExpectation(): Unit = {

--- a/shared/src/main/scala-2/com/eed3si9n/expecty/Recorder.scala
+++ b/shared/src/main/scala-2/com/eed3si9n/expecty/Recorder.scala
@@ -17,7 +17,13 @@ import language.experimental.macros
 
 abstract class Recorder[R, A] {
   def listener: RecorderListener[R, A]
+}
+
+trait UnaryRecorder[R, A] { self : Recorder[R, A] =>
   def apply(recording: R): A = macro RecorderMacro1.apply[R, A]
   def apply(recording: R, message: => String): A = macro RecorderMacro.apply[R, A]
-  def all(recordings: R*) : A = macro RecorderMacroAll.apply[R, A]
+}
+
+trait VarargsRecoder[R, A] { self : Recorder[R, A] =>
+  def apply(recordings: R*) : A = macro VarargsRecorderMacro.apply[R, A]
 }

--- a/shared/src/main/scala-2/com/eed3si9n/expecty/Recorder.scala
+++ b/shared/src/main/scala-2/com/eed3si9n/expecty/Recorder.scala
@@ -19,4 +19,5 @@ abstract class Recorder[R, A] {
   def listener: RecorderListener[R, A]
   def apply(recording: R): A = macro RecorderMacro1.apply[R, A]
   def apply(recording: R, message: => String): A = macro RecorderMacro.apply[R, A]
+  def all(recordings: R*) : A = macro RecorderMacroAll.apply[R, A]
 }

--- a/shared/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/shared/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
@@ -165,7 +165,7 @@ Instrumented AST: ${showRaw(instrumented)}")
 
 }
 
-object RecorderMacroAll {
+object VarargsRecorderMacro {
   def apply[R: context.WeakTypeTag, A: context.WeakTypeTag](context: Context)(recordings: context.Tree*): context.Expr[A] = {
     new RecorderMacro[context.type](context).all[R, A](recordings)
   }

--- a/shared/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
+++ b/shared/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
@@ -21,4 +21,6 @@ abstract class Recorder[R, A] {
     ${ RecorderMacro.apply('recording, 'listener) }
   inline def apply(recording: R, message: => String): A =
     ${ RecorderMacro.apply('recording, 'message, 'listener) }
+  inline def all(inline recordings: R*): A =
+    ${ RecorderMacro.all('recordings, 'listener)}
 }

--- a/shared/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
+++ b/shared/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
@@ -17,10 +17,16 @@ import language.experimental.macros
 
 abstract class Recorder[R, A] {
   def listener: RecorderListener[R, A]
+}
+
+trait UnaryRecorder[R, A] { self: Recorder[R, A] =>
   inline def apply(recording: R): A =
     ${ RecorderMacro.apply('recording, 'listener) }
   inline def apply(recording: R, message: => String): A =
     ${ RecorderMacro.apply('recording, 'message, 'listener) }
-  inline def all(inline recordings: R*): A =
-    ${ RecorderMacro.all('recordings, 'listener)}
+}
+
+trait VarargsRecoder[R, A] { self: Recorder[R, A] =>
+  inline def apply(inline recordings: R*): A =
+    ${ RecorderMacro.varargs('recordings, 'listener)}
 }

--- a/shared/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/shared/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
@@ -28,8 +28,23 @@ object RecorderMacro {
       recording: Expr[R],
       message: Expr[String],
       listener: Expr[RecorderListener[R, A]])(using QuoteContext): Expr[A] = {
+    apply(Seq(recording), message, listener)
+  }
+
+  def all[R: Type, A: Type](
+      recordings: Expr[Seq[R]],
+      listener: Expr[RecorderListener[R, A]])(using QuoteContext): Expr[A] = {
+    //!\ only works because we're expecting the macro to expand `R*`
+    val Varargs(unTraversedRecordings) = recordings
+    apply(unTraversedRecordings, '{""}, listener)
+  }
+
+  def apply[R: Type, A: Type](
+      recordings: Seq[Expr[R]],
+      message: Expr[String],
+      listener: Expr[RecorderListener[R, A]])(using QuoteContext): Expr[A] = {
     import qctx.tasty._
-    val termArg: Term = recording.unseal.underlyingArgument
+    val termArgs: Seq[Term] = recordings.map(_.unseal.underlyingArgument)
 
     def getText(expr: Tree): String = {
       val pos = expr.pos
@@ -165,7 +180,7 @@ object RecorderMacro {
             case _                => expr.pos.startColumn
           }
         Block(
-          recordExpressions(termArg),
+          termArgs.toList.flatMap(recordExpressions),
           '{ recorderRuntime.completeRecording() }.unseal
         ).seal.cast[A]
       }

--- a/shared/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/shared/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
@@ -31,7 +31,7 @@ object RecorderMacro {
     apply(Seq(recording), message, listener)
   }
 
-  def all[R: Type, A: Type](
+  def varargs[R: Type, A: Type](
       recordings: Expr[Seq[R]],
       listener: Expr[RecorderListener[R, A]])(using QuoteContext): Expr[A] = {
     //!\ only works because we're expecting the macro to expand `R*`

--- a/shared/src/main/scala/com/eed3si9n/expecty/Expecty.scala
+++ b/shared/src/main/scala/com/eed3si9n/expecty/Expecty.scala
@@ -14,7 +14,7 @@
 
 package com.eed3si9n.expecty
 
-class Expecty extends Recorder[Boolean, Unit] {
+abstract class ExpectyBase extends Recorder[Boolean, Unit] {
   val failEarly: Boolean = true
   val showTypes: Boolean = false
   val showLocation: Boolean = false
@@ -46,7 +46,10 @@ class Expecty extends Recorder[Boolean, Unit] {
   override lazy val listener = new ExpectyListener
 }
 
+class Expecty() extends ExpectyBase with UnaryRecorder[Boolean, Unit]
+class VarargsExpecty() extends ExpectyBase with VarargsRecoder[Boolean, Unit]
+
 object Expecty {
   lazy val assert: Expecty = new Expecty()
-  lazy val expect: Expecty = assert
+  lazy val expect: VarargsExpecty = new VarargsExpecty()
 }


### PR DESCRIPTION
More importantly, it adds the machinary to allow for more than one
expression to be recorded in a single macro expansion.

```scala 
assert(1 + 1 == 2)
assert(2 + 1 == 3)
assert(2 + 2 == 4)
```

can be rewritten as

```scala
assert.all(
  1 + 1 == 2,
  2 + 1 == 3,
  2 + 2 == 4
)
```