### PR TITLE
Fix source location NPE

### DIFF
--- a/shared/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/shared/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
@@ -157,7 +157,7 @@ Instrumented AST: ${showRaw(instrumented)}")
     val abstractFile = context.enclosingPosition.source.file
 
     val rp = if (!abstractFile.isVirtual){
-      pwd.relativize(abstractFile.file.toPath())
+      pwd.relativize(abstractFile.file.toPath()).toString()
     } else p
 
     val path = Literal(Constant(p))

--- a/shared/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/shared/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
@@ -154,8 +154,11 @@ Instrumented AST: ${showRaw(instrumented)}")
 
     val pwd  = java.nio.file.Paths.get("").toAbsolutePath
     val p = context.enclosingPosition.source.path
-    val file = context.enclosingPosition.source.file.file
-    val rp = pwd.relativize(file.toPath()).toString()
+    val abstractFile = context.enclosingPosition.source.file
+
+    val rp = if (!abstractFile.isVirtual){
+      pwd.relativize(abstractFile.file.toPath())
+    } else p
 
     val path = Literal(Constant(p))
     val relativePath = Literal(Constant(rp))

--- a/shared/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/shared/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
@@ -55,15 +55,20 @@ object RecorderMacro {
       val pos = expr.pos
 
       val pwd  = java.nio.file.Paths.get("").toAbsolutePath
-      val path = pos.sourceFile.jpath
-      val file = path.toFile
-
-      val pathExpr = Expr(path.toString)
-      val relativePath = Expr(pwd.relativize(path).toString())
       val line = Expr(pos.endLine)
-      val fileName = Expr(file.getName)
 
-      '{Location(${pathExpr}, ${relativePath}, ${line})}.unseal
+      val path = pos.sourceFile.jpath
+      if (path != null){
+        val file = path.toFile
+
+        val pathExpr = Expr(path.toString)
+        val relativePath = Expr(pwd.relativize(path).toString())
+        val fileName = Expr(file.getName)
+
+        '{Location(${pathExpr}, ${relativePath}, ${line})}.unseal
+      } else {
+        '{Location("<virtual>", "<virtual>", ${line})}.unseal
+      }
     }
 
     '{


### PR DESCRIPTION
Fixes https://github.com/eed3si9n/expecty/issues/30 

```
> java.lang.AssertionError: assertion failed (<console>:1)

foo(1 == "1")
      |
      false
``` 

Unfortunately dotty doesn't give as much information as Scala 2 (you just have access to the path, which may be null, or the contents, nothing else). I resorted to forcing the path values to  the `"<virtual>"` literal string when this happens. 