### PR TITLE
Respect "fail early" flag in case of varargs

### DIFF
--- a/shared/src/main/scala-2/com/eed3si9n/expecty/Recorder.scala
+++ b/shared/src/main/scala-2/com/eed3si9n/expecty/Recorder.scala
@@ -24,6 +24,6 @@ trait UnaryRecorder[R, A] { self : Recorder[R, A] =>
   def apply(recording: R, message: => String): A = macro RecorderMacro.apply[R, A]
 }
 
-trait VarargsRecoder[R, A] { self : Recorder[R, A] =>
+trait VarargsRecorder[R, A] { self : Recorder[R, A] =>
   def apply(recordings: R*) : A = macro VarargsRecorderMacro.apply[R, A]
 }

--- a/shared/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
+++ b/shared/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
@@ -26,7 +26,7 @@ trait UnaryRecorder[R, A] { self: Recorder[R, A] =>
     ${ RecorderMacro.apply('recording, 'message, 'listener) }
 }
 
-trait VarargsRecoder[R, A] { self: Recorder[R, A] =>
+trait VarargsRecorder[R, A] { self: Recorder[R, A] =>
   inline def apply(inline recordings: R*): A =
     ${ RecorderMacro.varargs('recordings, 'listener)}
 }


### PR DESCRIPTION
When "fail early" is set to false, all expressions that failed in an "expect" call will be displayed : 

``` 
scala> val expect = new com.eed3si9n.expecty.ExpectyBase with com.eed3si9n.expecty.VarargsRecorder[Boolean, Unit] { override val failEarly : Boolean = false }
val expect: com.eed3si9n.expecty.ExpectyBase with com.eed3si9n.expecty.VarargsRecorder[Boolean,Unit] = $anon$1@67649522

scala> val x = 1
val x: Int = 1

scala> expect(x == 1, x == 2, x == 3)
java.lang.AssertionError: assertions failed

expect(x == 1, x == 2, x == 3)
               | |
               1 false

expect(x == 1, x == 2, x == 3)
                       | |
                       1 false

  at com.eed3si9n.expecty.ExpectyBase$ExpectyListener.recordingCompleted(Expecty.scala:62)
  at com.eed3si9n.expecty.ExpectyBase$ExpectyListener.recordingCompleted(Expecty.scala:24)
  at com.eed3si9n.expecty.RecorderRuntime.completeRecording(RecorderRuntime.scala:46)
  ... 40 elided
```

Also, fixes a typo (VarargsRecorder)