### PR TITLE
Scala 2.12.13 (was 2.12.12)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,10 @@
 val scala211 = "2.11.12"
-val scala212 = "2.12.12"
+val scala212 = "2.12.13"
 val scala213 = "2.13.4"
 val scala3 = "3.0.0-M3"
 ThisBuild / scalaVersion := scala213
 Global / semanticdbEnabled := true
+Global / semanticdbVersion := "4.4.7"
 
 lazy val verify = "com.eed3si9n.verify" %% "verify" % "1.0.0"
 


### PR DESCRIPTION
newer semanticdb version is needed on 2.12.13

(note to self: once this is merged, I'll need to update `proj/expecty.conf` in the community build)