### PR TITLE
Scala Native 0.4.0 (2.12 and 2.13)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,13 +47,7 @@ lazy val expecty = (projectMatrix in file("."))
     )
   )
   .jsPlatform(scalaVersions = Seq(scala213, scala212, scala211, scala3))
-  .nativePlatform(
-    scalaVersions = Seq(scala211),
-    settings = Seq(
-      bspEnabled := false,
-      Test / test := { () },
-    )
-  )
+  .nativePlatform(scalaVersions = Seq(scala211, scala212, scala213))
 
 lazy val expecty3 = expecty
   .jvm(scala3)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ val scalaJSVersion =
 
 // 0.4.0-M2's BigDecimal doesn't work https://github.com/scala-native/scala-native/issues/1770
 val scalaNativeVersion =
-  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.3.9")
+  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.0")
 
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.6.0")


### PR DESCRIPTION
At some point should probably convert tests from JUnit to Verify and run them not only on jvm