### PR TITLE
Fix implicit parameter list capture

### DIFF
--- a/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
@@ -160,7 +160,14 @@ Instrumented AST: ${showRaw(instrumented)}")
         // Inner Apply is the application of the value the extension applies to.
         // Outer Apply is the application of implicit parameters
         Apply(Apply(x, y.map(recordAllValues)), z)
-      case Apply(x, ys)     => Apply(recordAllValues(x), ys.map(recordAllValues))
+      case Apply(x, ys) =>
+        val allParametersAreImplicit =
+          ys.map(x => Option(x.symbol).fold(false)(_.isImplicit)).forall(_ == true)
+
+        if (ys.nonEmpty && allParametersAreImplicit)
+          Apply(recordSubValues(x), ys)
+        else
+          Apply(recordAllValues(x), ys.map(recordAllValues))
       case TypeApply(x, ys) => TypeApply(recordSubValues(x), ys)
       case Select(x, y)     => Select(recordAllValues(x), y)
       case _                => expr

--- a/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
@@ -130,6 +130,8 @@ class RecorderMacro(using qctx0: Quotes) {
     }
   }
 
+  private[this] def isImplicitParameter(t: Term): Boolean = 
+    t.symbol.flags.is(Flags.Given) || t.symbol.flags.is(Flags.Implicit)
 
   private[this] def recordSubValues(runtime: Term, expr: Term): Term = {
     expr match {
@@ -150,7 +152,11 @@ class RecorderMacro(using qctx0: Quotes) {
         }
       case a @ Apply(x, ys) =>
         try {
-          Apply(recordAllValues(runtime, x), ys.map(recordAllValues(runtime, _)))
+  
+          if(ys.nonEmpty && ys.forall(isImplicitParameter))
+            Apply(recordSubValues(runtime, x), ys)
+          else 
+            Apply(recordSubValues(runtime, x), ys.map(recordAllValues(runtime, _)))
         } catch {
           case e: AssertionError => expr
         }

--- a/src/test/scala-3/ExpectyScala3Test.scala
+++ b/src/test/scala-3/ExpectyScala3Test.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package foo
+
+object ExpectyScala3Test extends verify.BasicTestSuite {
+  import com.eed3si9n.expecty.Expecty.expect
+  val assert1 = com.eed3si9n.expecty.Expecty.assert
+
+  import java.lang.AssertionError
+
+  val name = "Hi from Expecty!"
+
+   trait Eq[T]:
+     def eq(x: T, y: T): Boolean
+
+   object Eq:
+     given Eq[Int] with
+       def eq(x: Int, y: Int) = (x - y) == 0
+
+  test("scala 3 extension (1)") {
+    // Regression test for https://github.com/eed3si9n/expecty/issues/50
+    extension [T](i: T)(using eq: Eq[T])
+      def ===(other: T) = eq.eq(i, other)
+
+    assert1("abc".length() === 3)
+  }
+
+  test("scala 3 extension (2)") {
+    // Regression test for https://github.com/eed3si9n/expecty/issues/50
+    extension [T](i: T)
+      def ===(other: T)(using eq: Eq[T]) = eq.eq(i, other)
+
+    assert1("abc".length() === 3)
+  }
+
+  test("Method with implicit parameter") {
+    trait Test[T]:
+      def a: T
+
+    given ti: Test[Int] with
+      def a = 25
+
+    val ti2 = new Test[Int]:
+      def a = 50
+
+    trait Data:
+      def hello[T: Test](b: T) = (summon[Test[T]].a, b)
+      override def toString = "Data"
+
+    val z = new Data {}
+
+    assert1(z.hello(50)(using ti2) == 50 -> 50)
+    assert1(z.hello(128) == 25 -> 128)
+  }
+}
+

--- a/src/test/scala/ExpectyTest.scala
+++ b/src/test/scala/ExpectyTest.scala
@@ -15,7 +15,9 @@
 package foo
 
 object ExpectyTest extends verify.BasicTestSuite {
+  import com.eed3si9n.expecty.Expecty.expect
   val assert1 = com.eed3si9n.expecty.Expecty.assert
+
   import java.lang.AssertionError
 
   val name = "Hi from Expecty!"
@@ -69,5 +71,24 @@ object ExpectyTest extends verify.BasicTestSuite {
     }
 
     assert1("abc".length() === 3)
+
+  }
+
+  test("Method with implicit parameter") {
+    trait Test[T] {
+      def a: T
+    }
+
+    implicit val testInt: Test[Int] = new Test[Int] {
+      def a = 25
+    }
+
+    trait Data {
+      def hello[T: Test](b: T) = (implicitly[Test[T]].a, b)
+    }
+
+    val z = new Data {}
+
+    assert1(z.hello[Int](50) == 25 -> 50)
   }
 }


### PR DESCRIPTION
This particular case seems to have slipped through in #51 

Wasn't working before Oli's PR as well.

----

Problem is breaking apart multiple argument lists - adding `recordValue` in the wrong place (between an implicit and non-implicit parameter list), seems to break things.

The way to fix it is to avoid putting recorders on the implicit parameters (not tearing them away from a method call).

This, obviously, is the stuff of nightmares in Scala 3, where you can do anything:

```scala
scala> def hello(x: String)(using Int, List[String])(t: Double)(using what: Set[Int]) = ???
def hello
  (x: String)
    (using x$2: Int, x$3: List[String])
      (t: Double)(using what: Set[Int]): Nothing
```

