### PR TITLE
Disable SJS 0.6, SN 0.4.0-M2 and update readme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,4 @@ jobs:
           sudo apt-get update
           sudo apt install clang libunwind-dev libgc-dev libre2-dev
           sbt -v ci-release
-          env SCALAJS_VERSION="0.6.33" CI_RELEASE="clean;expectyJS2_11/publishSigned;expectyJS2_12/publishSigned;expectyJS/publishSigned" sbt -v ci-release
-          env SCALANATIVE_VERSION="0.4.0-M2" CI_RELEASE="clean;expectyNative2_11/publishSigned" sbt -v ci-release
         shell: bash

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Expecty is licensed under the Apache 2 license.
 
 ## Setup
 
-[![Latest version](https://index.scala-lang.org/com.eed3si9n.expecty/expecty/latest.svg?color=orange)](https://index.scala-lang.org/com.eed3si9n.expecty/expecty)
+[![expecty Scala version support](https://index.scala-lang.org/eed3si9n/expecty/expecty/latest-by-scala-version.svg?color=orange)](https://index.scala-lang.org/eed3si9n/expecty/expecty)
 
 ```scala
-libraryDependencies += "com.eed3si9n.expecty" %% "expecty" % "0.15.4" % Test
+libraryDependencies += "com.eed3si9n.expecty" %% "expecty" % "<version (see above)>" % Test
 ```
 
 | Scala Version | JVM | JS (1.x) | Native (0.4.x) |

--- a/README.md
+++ b/README.md
@@ -11,9 +11,20 @@ Expecty is licensed under the Apache 2 license.
 
 ## Setup
 
+[![Latest version](https://index.scala-lang.org/com.eed3si9n.expecty/expecty/latest.svg?color=orange)](https://index.scala-lang.org/com.eed3si9n.expecty/expecty)
+
 ```scala
-libraryDependencies += "com.eed3si9n.expecty" %% "expecty" % "0.15.1" % Test
+libraryDependencies += "com.eed3si9n.expecty" %% "expecty" % "0.15.4" % Test
 ```
+
+| Scala Version | JVM | JS (1.x) | Native (0.4.x) |
+| ------------- | :-: | :------: | :------------: |
+| 3.0.0         | ✅  |   ✅     |     n/a        |
+| 2.13.x        | ✅  |   ✅     |     ✅         |
+| 2.12.x        | ✅  |   ✅     |     ✅         |
+| 2.11.x        | ✅  |   ✅     |     ✅         |
+
+
 
 ## Code Examples
 


### PR DESCRIPTION
* Removed SJS 0.6 (it no longer works on releases, Scala version too new)
* Removed SN 0.4.0-M2 in favour of stable 0.4.0
* Moved the versions table to README, as I keep copy pasting it into release notes