### PR TITLE
[bugfix] capturing package names crashes at runtime

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.5.5

--- a/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
@@ -29,6 +29,7 @@ class RecorderMacro(using qctx0: Quotes) {
       listener: Expr[RecorderListener[A, R]])(using qctx0: Quotes): Expr[R] = {
     val termArgs: Seq[Term] = recordings.map(_.asTerm.underlyingArgument)
 
+
     '{
       val recorderRuntime: RecorderRuntime[A, R] = new RecorderRuntime($listener)
       recorderRuntime.recordMessage($message)
@@ -162,7 +163,10 @@ class RecorderMacro(using qctx0: Quotes) {
         }
       // case TypeApply(x, ys) => recordValue(TypeApply.copy(expr)(recordSubValues(x), ys), expr)
       case TypeApply(x, ys) => TypeApply.copy(expr)(recordSubValues(runtime, x), ys)
-      case Select(x, y)     => Select.copy(expr)(recordAllValues(runtime, x), y)
+      case Select(x, y)     => 
+        if(!x.symbol.flags.is(Flags.Package))
+          Select.copy(expr)(recordAllValues(runtime, x), y)
+        else expr
       case Typed(x, tpe)    => Typed.copy(expr)(recordSubValues(runtime, x), tpe)
       case Repeated(xs, y)  => Repeated.copy(expr)(xs.map(recordAllValues(runtime, _)), y)
       case _                => expr
@@ -198,6 +202,7 @@ class RecorderMacro(using qctx0: Quotes) {
         case sym if sym.isValDef => skipIdent(sym)
         case _ => true
       })
+    
     expr match {
       case Select(_, _) if skipSelect(expr.symbol) => expr
       case TypeApply(_, _) => expr

--- a/src/test/scala-3/ExpectyScala3Test.scala
+++ b/src/test/scala-3/ExpectyScala3Test.scala
@@ -64,5 +64,9 @@ object ExpectyScala3Test extends verify.BasicTestSuite {
     assert1(z.hello(50)(using ti2) == 50 -> 50)
     assert1(z.hello(128) == 25 -> 128)
   }
+
+  test("Capturing package names correctly") {
+    assert1(cats.data.Chain(1, 2, 3).size == 3)
+  }
 }
 

--- a/src/test/scala-3/Fixtures.scala
+++ b/src/test/scala-3/Fixtures.scala
@@ -1,0 +1,7 @@
+package cats {
+  package data {
+    object Chain {
+      def apply[A](a: A*) : List[A] = List(a*)
+    }
+  }
+}


### PR DESCRIPTION
This is the minimal reproduction and fix for #54.

General idea is just to forget any symbols that have a Package flag.

While this fixes the repro and is small enough to seem generic enough, I don't think it does a great job in terms of failure rendering:

```
[info] - Capturing package names correctly *** FAILED ***
[info]   assertion failed
[info]   
[info]   cats.data.Chain(1, 2, 3).size != 3
[info]   |         |              |    |
[info]   |         |              3    false
[info]   |         cats.data.Chain$@34f86192
[info]   List(1, 2, 3)
[info]     com.eed3si9n.expecty.ExpectyBase$ExpectyListener.expressionRecorded(Expecty.scala:41)
[info]     com.eed3si9n.expecty.RecorderRuntime.recordExpression(RecorderRuntime.scala:40)
[info]     foo.ExpectyScala3Test$.$init$$$anonfun$4(ExpectyScala3Test.scala:73)
```

Although I can be persuaded that it's the way it's supposed to work, given the nature of power assertions :)

@eed3si9n @Baccata if you agree that it's *a* fix, I say we merge and release, and create another issue for all the strange Scala 3 only fixes we had to do - feels like we need a much more systematic approach for those things. 