### PR TITLE
Fix relativisation edge-case (Windows)

### DIFF
--- a/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
@@ -209,6 +209,8 @@ Instrumented AST: ${showRaw(instrumented)}")
     val p = context.enclosingPosition.source.path
     val abstractFile = context.enclosingPosition.source.file
 
+    // Comparing roots to avoid the windows-specific edge case of relativisation crashing
+    // because the CWD and the source file are in two different drives (C:/ and D:/ for instance).
     val rp = if (!abstractFile.isVirtual && pwd.getRoot() == abstractFile.file.toPath.getRoot()) {
       pwd.relativize(abstractFile.file.toPath()).toString()
     } else p

--- a/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
@@ -209,7 +209,7 @@ Instrumented AST: ${showRaw(instrumented)}")
     val p = context.enclosingPosition.source.path
     val abstractFile = context.enclosingPosition.source.file
 
-    val rp = if (!abstractFile.isVirtual) {
+    val rp = if (!abstractFile.isVirtual && pwd.getRoot() == abstractFile.file.toPath.getRoot()) {
       pwd.relativize(abstractFile.file.toPath()).toString()
     } else p
 

--- a/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
@@ -69,6 +69,8 @@ class RecorderMacro(using qctx0: Quotes) {
     val line = Expr(pos.endLine)
 
     val path = pos.sourceFile.jpath
+    // Comparing roots to avoid the windows-specific edge case of relativisation crashing
+    // because the CWD and the source file are in two different drives (C:/ and D:/ for instance).
     if (path != null && path.getRoot() == pwd.getRoot()){
       val file = path.toFile
 

--- a/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/src/main/scala-3/com/eed3si9n/expecty/RecorderMacro.scala
@@ -69,7 +69,7 @@ class RecorderMacro(using qctx0: Quotes) {
     val line = Expr(pos.endLine)
 
     val path = pos.sourceFile.jpath
-    if (path != null){
+    if (path != null && path.getRoot() == pwd.getRoot()){
       val file = path.toFile
 
       val pathExpr = Expr(path.toString)
@@ -130,7 +130,7 @@ class RecorderMacro(using qctx0: Quotes) {
     }
   }
 
-  private[this] def isImplicitParameter(t: Term): Boolean = 
+  private[this] def isImplicitParameter(t: Term): Boolean =
     t.symbol.flags.is(Flags.Given) || t.symbol.flags.is(Flags.Implicit)
 
   private[this] def recordSubValues(runtime: Term, expr: Term): Term = {
@@ -152,10 +152,10 @@ class RecorderMacro(using qctx0: Quotes) {
         }
       case a @ Apply(x, ys) =>
         try {
-  
+
           if(ys.nonEmpty && ys.forall(isImplicitParameter))
             Apply(recordSubValues(runtime, x), ys)
-          else 
+          else
             Apply(recordSubValues(runtime, x), ys.map(recordAllValues(runtime, _)))
         } catch {
           case e: AssertionError => expr


### PR DESCRIPTION
There seem to be a pretty weird edge case where paths cannot be relativised
because the compiled file is on another disk (for instance C:/) than the
CWD (D:/).

See https://github.com/VirtuslabRnD/scala-cli/pull/105/checks?check_run_id=3441114875

Checking that the roots match seem to do the trick