### PR TITLE
Publish on pushes to develop branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main]
+    branches: [develop]
     tags: ["*"]
 jobs:
   publish:


### PR DESCRIPTION
We've got #56 and #55 that should probably be tested with snapshots first before releasing completely.

Whilst I'm touching those, @Baccata should we add windows-latest to the build matrix? Given that now there's going to be an OS-specific bit of code in Expecty.