### PR TITLE
bump, bump, bump your versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ libraryDependencies += "com.eed3si9n.expecty" %% "expecty" % "<version (see abov
 
 | Scala Version | JVM | JS (1.x) | Native (0.4.x) |
 | ------------- | :-: | :------: | :------------: |
-| 3.0.0         | ✅  |   ✅     |     n/a        |
+| 3.0           | ✅  |   ✅     |     n/a        |
 | 2.13.x        | ✅  |   ✅     |     ✅         |
 | 2.12.x        | ✅  |   ✅     |     ✅         |
 | 2.11.x        | ✅  |   ✅     |     ✅         |
@@ -29,7 +29,7 @@ libraryDependencies += "com.eed3si9n.expecty" %% "expecty" % "<version (see abov
 ## Code Examples
 
 ```scala
-Welcome to Scala 2.12.8 (OpenJDK 64-Bit Server VM, Java 1.8.0_212).
+Welcome to Scala 2.12.15 (OpenJDK 64-Bit Server VM, Java 1.8.0_212).
 Type in expressions for evaluation. Or try :help.
 
 scala> import com.eed3si9n.expecty.Expecty.assert

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val scala211 = "2.11.12"
-val scala212 = "2.12.13"
-val scala213 = "2.13.5"
-val scala3 = "3.0.0"
+val scala212 = "2.12.15"
+val scala213 = "2.13.8"
+val scala3 = "3.0.2"
 ThisBuild / scalaVersion := scala213
 Global / semanticdbEnabled := true
 Global / semanticdbVersion := "4.4.17"

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val expecty = (projectMatrix in file("."))
     settings = Seq(
       libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
       Test / unmanagedSourceDirectories ++= {
-        Seq((baseDirectory in LocalRootProject).value / "jvm" / "src" / "test" / "scala")
+        Seq((LocalRootProject / baseDirectory).value / "jvm" / "src" / "test" / "scala")
       },
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val scala213 = "2.13.8"
 val scala3 = "3.0.2"
 ThisBuild / scalaVersion := scala213
 Global / semanticdbEnabled := true
-Global / semanticdbVersion := "4.4.17"
+Global / semanticdbVersion := "4.5.0"
 
 lazy val verify = "com.eed3si9n.verify" %% "verify" % "1.0.0"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,7 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.5.0")
-
-// 0.4.0-M2's BigDecimal doesn't work https://github.com/scala-native/scala-native/issues/1770
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.9.0")
 val scalaNativeVersion =
-  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.0")
+  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.4")
 
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.6.0")


### PR DESCRIPTION
 context: in the Scala 2 community build, with the latest 2.13.9 nightly, expecty is failing. in order to investigate, I'm looking to reduce the differences between what this repo uses and what the community build uses.

even outside of that specific context, though, I think expecty should take these version bumps, on general principle.