### PR TITLE
Merge adjacent tokens in diffs

### DIFF
--- a/src/main/scala/com/eed3si9n/expecty/DiffUtil.scala
+++ b/src/main/scala/com/eed3si9n/expecty/DiffUtil.scala
@@ -169,8 +169,30 @@ object DiffUtil {
   private final case class Deleted(str: String) extends Patch
   private final case class Inserted(str: String) extends Patch
 
+  private class PatchBuilder() {
+    private var lastVisited = Option.empty[Patch]
+    private val builder = Array.newBuilder[Patch]
+
+    def +=(patch: Patch) = (lastVisited, patch) match {
+      case (None, patch) =>
+        lastVisited = Some(patch)
+      case (Some(Deleted(a)), Deleted(b)) =>
+        lastVisited = Some(Deleted(a + b))
+      case (Some(Inserted(a)), Inserted(b)) =>
+        lastVisited = Some(Inserted(a + b))
+      case (Some(last), patch) =>
+        builder += last
+        lastVisited = Some(patch)
+    }
+
+    def result(): Array[Patch] = {
+      lastVisited.foreach(builder.+=)
+      builder.result()
+    }
+  }
+
   private def hirschberg(a: Array[String], b: Array[String]): Array[Patch] = {
-    def build(x: Array[String], y: Array[String], builder: mutable.ArrayBuilder[Patch]): Unit =
+    def build(x: Array[String], y: Array[String], builder: PatchBuilder): Unit =
       if (x.isEmpty)
         builder += Inserted(y.mkString)
       else if (y.isEmpty)
@@ -194,7 +216,7 @@ object DiffUtil {
         build(x1, y1, builder)
         build(x2, y2, builder)
       }
-    val builder = Array.newBuilder[Patch]
+    val builder = new PatchBuilder()
     build(a, b, builder)
     builder.result()
   }
@@ -219,7 +241,7 @@ object DiffUtil {
     Array.tabulate(y.length + 1)(j => score(x.length)(j))
   }
 
-  private def needlemanWunsch(x: Array[String], y: Array[String], builder: mutable.ArrayBuilder[Patch]): Unit = {
+  private def needlemanWunsch(x: Array[String], y: Array[String], builder: PatchBuilder): Unit = {
     def similarity(a: String, b: String) = if (a == b) 2 else -1
     val d = 1
     val score = Array.tabulate(x.length + 1, y.length + 1) { (i, j) =>
@@ -252,6 +274,6 @@ object DiffUtil {
       alignment = Inserted(y(j - 1)) :: alignment
       j = j - 1
     }
-    builder ++= alignment
+    alignment.foreach(builder += _)
   }
 }

--- a/src/main/scala/com/eed3si9n/expecty/DiffUtil.scala
+++ b/src/main/scala/com/eed3si9n/expecty/DiffUtil.scala
@@ -169,7 +169,7 @@ object DiffUtil {
   private final case class Deleted(str: String) extends Patch
   private final case class Inserted(str: String) extends Patch
 
-  private class PatchBuilder() {
+  private class PatchArrayBuilder() {
     private var lastVisited = Option.empty[Patch]
     private val builder = Array.newBuilder[Patch]
 
@@ -192,7 +192,7 @@ object DiffUtil {
   }
 
   private def hirschberg(a: Array[String], b: Array[String]): Array[Patch] = {
-    def build(x: Array[String], y: Array[String], builder: PatchBuilder): Unit =
+    def build(x: Array[String], y: Array[String], builder: PatchArrayBuilder): Unit =
       if (x.isEmpty)
         builder += Inserted(y.mkString)
       else if (y.isEmpty)
@@ -216,7 +216,7 @@ object DiffUtil {
         build(x1, y1, builder)
         build(x2, y2, builder)
       }
-    val builder = new PatchBuilder()
+    val builder = new PatchArrayBuilder()
     build(a, b, builder)
     builder.result()
   }
@@ -241,7 +241,7 @@ object DiffUtil {
     Array.tabulate(y.length + 1)(j => score(x.length)(j))
   }
 
-  private def needlemanWunsch(x: Array[String], y: Array[String], builder: PatchBuilder): Unit = {
+  private def needlemanWunsch(x: Array[String], y: Array[String], builder: PatchArrayBuilder): Unit = {
     def similarity(a: String, b: String) = if (a == b) 2 else -1
     val d = 1
     val score = Array.tabulate(x.length + 1, y.length + 1) { (i, j) =>

--- a/src/test/scala/DiffUtilTest.scala
+++ b/src/test/scala/DiffUtilTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package foo
+
+import com.eed3si9n.expecty._
+
+object DiffUtilTest extends verify.BasicTestSuite {
+
+  test("should merge adjacent tokens in diff when inserting") {
+    val expected = "[1,2,3,4,5]"
+    val actual = "[1,5]"
+
+    val (expectedDiff, actualDiff) = DiffUtil.mkColoredLineDiff(expected, actual)
+    Expecty.assert(expectedDiff == s"[1,${Console.BOLD}${Console.GREEN}[2,3,4,]${Console.RESET}5]")
+    Expecty.assert(actualDiff == "[1,5]")
+  }
+  test("should merge adjacent tokens in diff when deleting") {
+    val expected = "[1,5]"
+    val actual = "[1,2,3,4,5]"
+
+    val (expectedDiff, actualDiff) = DiffUtil.mkColoredLineDiff(expected, actual)
+    Expecty.assert(actualDiff == s"[1${Console.BOLD}${Console.RED}[,2,3,4]${Console.RESET},5]")
+    Expecty.assert(expectedDiff == "[1,5]")
+  }
+}


### PR DESCRIPTION
The way diffs are displayed today is hard to read with strings with many separators.
This PR merges `Inserted` and `Deleted` blocks in diffs so they are easier to read.

Before:
<img width="1205" alt="before" src="https://github.com/user-attachments/assets/6ef6ba58-d544-4b93-ad87-c1ac344dfd3d">

After:
<img width="1206" alt="after" src="https://github.com/user-attachments/assets/088535fe-5691-4e77-835b-61484d9b4ab0">
